### PR TITLE
fix(ensemble): cherry-pick eventlet deadlock fixes + seamless model loading from master

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ mkdir -p uploads results logs run
 python3 api.py
 ```
 
-The first video analysis request triggers model loading (2-4 min on CPU). Subsequent requests are ~10-20 seconds. Health check: `curl http://localhost:5000/api/health`.
+Ensemble models auto-preload in a background thread at startup (~50-60s on CPU). Login/health/dashboard work instantly during this time. Poll `/api/ensemble-status` for per-model progress. Health check: `curl http://localhost:5000/api/health`.
 
 ### Starting the frontend
 

--- a/ai_model/ensemble_detector.py
+++ b/ai_model/ensemble_detector.py
@@ -544,87 +544,131 @@ class EnsembleDetector:
         }
 
 
-# Global instance; loaded in background thread so the request thread never blocks
+# ---------------------------------------------------------------------------
+# Global ensemble lifecycle: background preload, per-model status, resilient retry
+# ---------------------------------------------------------------------------
 import threading as _threading
-_ensemble_instance = None
-_ensemble_init_failed = False
+import time as _time
+
+_ensemble_instance: Optional[EnsembleDetector] = None
 _ensemble_loading_started = False
 _ensemble_loading_lock = _threading.Lock()
+_ensemble_load_start_time: Optional[float] = None
+
+# Per-model status tracking so the frontend can show a real progress bar
+_MODEL_NAMES = ['clip', 'resnet', 'v13', 'xception', 'efficientnet']
+_model_status: Dict[str, str] = {m: 'pending' for m in _MODEL_NAMES}  # pending | loading | loaded | failed
+_ensemble_overall_status = 'idle'  # idle | loading | ready | failed
+_ensemble_fail_count = 0
+_RETRY_COOLDOWN = 30  # seconds before allowing retry after failure
+_last_fail_time: Optional[float] = None
+
+
+def get_ensemble_status() -> Dict[str, Any]:
+    """Return detailed loading status for the /api/ensemble-status endpoint.
+    Never blocks. Safe to call from any thread at any time."""
+    elapsed = round(_time.time() - _ensemble_load_start_time, 1) if _ensemble_load_start_time else 0
+    models = dict(_model_status)
+    loaded_count = sum(1 for s in models.values() if s == 'loaded')
+    total = len(models)
+    if _ensemble_overall_status == 'ready':
+        pct = 100
+    elif _ensemble_overall_status == 'loading':
+        pct = max(5, int(loaded_count / total * 90))  # 5-90% while loading
+    else:
+        pct = 0
+    return {
+        'status': _ensemble_overall_status,
+        'progress_pct': pct,
+        'models': models,
+        'models_loaded': loaded_count,
+        'models_total': total,
+        'elapsed_seconds': elapsed,
+        'ready': _ensemble_overall_status == 'ready',
+    }
+
 
 def init_ensemble_blocking() -> Optional[EnsembleDetector]:
-    """
-    Load the full ensemble in the current thread. Called only from the background
-    loader thread so the request thread never blocks for 10+ min.
-    """
-    global _ensemble_instance, _ensemble_init_failed
+    """Load the full ensemble in the current thread (called from background thread only)."""
+    global _ensemble_instance, _ensemble_overall_status, _ensemble_fail_count
+    global _last_fail_time, _ensemble_load_start_time
     if _ensemble_instance is not None:
         return _ensemble_instance
-    if _ensemble_init_failed:
-        return None
+    _ensemble_overall_status = 'loading'
+    _ensemble_load_start_time = _time.time()
+    for m in _MODEL_NAMES:
+        _model_status[m] = 'loading'
     try:
-        logger.info("Loading full ensemble (CLIP + ResNet + V13 + XceptionNet + EfficientNet + ...) — this may take 2–5 minutes.")
-        _ensemble_instance = EnsembleDetector()
-        logger.info("✅ EnsembleDetector loaded successfully. Every scan will use the full ensemble.")
-        return _ensemble_instance
+        logger.info("Loading full ensemble (CLIP + ResNet + V13 + XceptionNet + EfficientNet) — this may take 2–4 minutes.")
+        det = EnsembleDetector()
+        _ensemble_instance = det
+        _ensemble_overall_status = 'ready'
+        # Update per-model status from actual detector state
+        _model_status['clip'] = 'loaded' if det.clip_detector else 'failed'
+        _model_status['resnet'] = 'loaded' if det.resnet_model else 'failed'
+        _model_status['v13'] = 'loaded' if (det.v13_detector and getattr(det.v13_detector, 'model_loaded', False)) else 'failed'
+        _model_status['xception'] = 'loaded' if det.xception_detector else 'failed'
+        _model_status['efficientnet'] = 'loaded' if det.efficientnet_detector else 'failed'
+        elapsed = round(_time.time() - _ensemble_load_start_time, 1)
+        logger.info(f"✅ EnsembleDetector loaded in {elapsed}s. Models: {_model_status}")
+        return det
     except Exception as e:
         logger.exception(f"EnsembleDetector initialization failed: {e}")
-        _ensemble_init_failed = True
+        _ensemble_overall_status = 'failed'
+        _ensemble_fail_count += 1
+        _last_fail_time = _time.time()
+        for m in _MODEL_NAMES:
+            if _model_status[m] == 'loading':
+                _model_status[m] = 'failed'
         return None
 
+
 def start_background_ensemble_load() -> None:
-    """
-    Start loading the ensemble in a background thread if not already loaded or loading.
-    Returns immediately. The request thread must never block on model load — so the
-    first scan returns 503 and the user retries in 3 min when the background load has finished.
-    """
-    global _ensemble_instance, _ensemble_init_failed, _ensemble_loading_started
+    """Start loading the ensemble in a background thread. Returns immediately.
+    Safe to call multiple times — subsequent calls are no-ops unless a retry is due."""
+    global _ensemble_loading_started, _ensemble_overall_status
     with _ensemble_loading_lock:
         if _ensemble_instance is not None:
             return
-        if _ensemble_init_failed:
-            return
-        if _ensemble_loading_started:
-            return
+        if _ensemble_loading_started and _ensemble_overall_status == 'loading':
+            return  # already in progress
+        # Allow retry after cooldown on failure
+        if _ensemble_overall_status == 'failed':
+            if _last_fail_time and (_time.time() - _last_fail_time) < _RETRY_COOLDOWN:
+                return  # too soon to retry
+            logger.info(f"Retrying ensemble load (attempt {_ensemble_fail_count + 1}) after cooldown...")
+            _ensemble_overall_status = 'loading'
         _ensemble_loading_started = True
+
     def _run():
         try:
             init_ensemble_blocking()
-        finally:
-            pass  # _ensemble_instance or _ensemble_init_failed is set
-    t = _threading.Thread(target=_run, daemon=True)
+        except Exception:
+            pass  # status already set inside init_ensemble_blocking
+    t = _threading.Thread(target=_run, daemon=True, name='ensemble-loader')
     t.start()
-    logger.info("Ensemble load started in background. Next scan (in ~3 min) will use it.")
+    logger.info("Ensemble load started in background thread.")
+
 
 def get_ensemble_detector(timeout: Optional[float] = None) -> Optional[EnsembleDetector]:
-    """
-    Return the global ensemble detector if already loaded. Never blocks — if not loaded,
-    returns None so the API can return 503 and ask the user to retry in 3 min.
-    """
-    global _ensemble_instance
+    """Return the global ensemble detector if already loaded. Never blocks."""
     return _ensemble_instance
 
+
 def detect_fake_ensemble(video_path: str, num_frames: int = 16) -> Dict[str, Any]:
-    """
-    Convenience function for ensemble detection with timeout protection
-    
-    Args:
-        video_path: Path to video file
-        num_frames: Number of frames to sample
-        
-    Returns:
-        Detection results or error dict if ensemble unavailable
-    """
-    detector = get_ensemble_detector()  # uses ENSEMBLE_INIT_TIMEOUT (default 300s)
+    """Convenience function for ensemble detection. Returns error dict if not ready."""
+    detector = get_ensemble_detector()
     if detector is None:
-        # Ensemble unavailable - return error result
+        start_background_ensemble_load()  # ensure loading is in progress
+        status = get_ensemble_status()
         return {
-            'error': 'Ensemble detector unavailable (initialization failed or timed out)',
+            'error': 'Ensemble detector is still loading. It will be ready shortly.',
             'is_deepfake': False,
             'confidence': 0.0,
             'ensemble_fake_probability': 0.5,
-            'method': 'ensemble_unavailable'
+            'method': 'ensemble_unavailable',
+            'ensemble_status': status,
         }
-    
     try:
         return detector.detect(video_path, num_frames)
     except Exception as e:
@@ -636,4 +680,13 @@ def detect_fake_ensemble(video_path: str, num_frames: int = 16) -> Dict[str, Any
             'ensemble_fake_probability': 0.5,
             'method': 'ensemble_error'
         }
+
+
+# ---------------------------------------------------------------------------
+# AUTO-START: Begin loading immediately when this module is imported.
+# This runs during app startup (api.py import), so by the time a user logs in
+# and navigates to Forensics the models are likely already loaded.
+# It is a daemon thread — zero impact on login, health checks, or any endpoint.
+# ---------------------------------------------------------------------------
+start_background_ensemble_load()
 

--- a/ai_model/ensemble_detector.py
+++ b/ai_model/ensemble_detector.py
@@ -669,18 +669,12 @@ def start_background_ensemble_load() -> None:
         except Exception:
             pass  # status already set inside init_ensemble_blocking
 
-    # Detect eventlet: if active, use tpool (real OS threads) to avoid deadlock.
-    # Green threads cannot do heavy CPU/IO (PyTorch model loading) without
-    # blocking the hub. tpool.execute runs in a real thread that eventlet manages.
-    _use_eventlet_tpool = False
-    try:
-        import eventlet
-        if hasattr(eventlet, 'sleep') and _threading.__name__ != 'threading':
-            _use_eventlet_tpool = True
-    except ImportError:
-        pass
+    # Detect eventlet by checking the env var the docker-compose and api.py use.
+    _use_eventlet = os.getenv('SOCKETIO_ASYNC_MODE', '').lower() == 'eventlet'
 
-    if _use_eventlet_tpool:
+    if _use_eventlet:
+        # Green threads deadlock on heavy PyTorch loads. Use eventlet.tpool
+        # (real OS thread pool) — same mechanism the scan analysis path uses.
         import eventlet as _ev
         def _tpool_wrapper():
             try:

--- a/ai_model/ensemble_detector.py
+++ b/ai_model/ensemble_detector.py
@@ -696,13 +696,19 @@ def get_ensemble_detector(timeout: Optional[float] = None) -> Optional[EnsembleD
 
 
 def detect_fake_ensemble(video_path: str, num_frames: int = 16) -> Dict[str, Any]:
-    """Convenience function for ensemble detection. Returns error dict if not ready."""
+    """Convenience function for ensemble detection.
+    If the ensemble isn't loaded yet, loads it inline (works because the caller
+    — api.py — already runs this inside eventlet.tpool.execute)."""
     detector = get_ensemble_detector()
     if detector is None:
-        start_background_ensemble_load()  # ensure loading is in progress
+        # Load models right here. This is safe because api.py wraps the entire
+        # analysis in tpool.execute() which runs in a real OS thread.
+        logger.info("Ensemble not loaded yet — loading inline (first scan, takes 2-4 min)...")
+        detector = init_ensemble_blocking()
+    if detector is None:
         status = get_ensemble_status()
         return {
-            'error': 'Ensemble detector is still loading. It will be ready shortly.',
+            'error': 'Ensemble detector failed to load. Check server logs.',
             'is_deepfake': False,
             'confidence': 0.0,
             'ensemble_fake_probability': 0.5,

--- a/ai_model/ensemble_detector.py
+++ b/ai_model/ensemble_detector.py
@@ -83,7 +83,12 @@ class EnsembleDetector:
         logger.info(f"🔧 Initializing EnsembleDetector on device: {self.device}")
         
         # Load CLIP + ResNet + V13 + Xception + EfficientNet ALL IN PARALLEL so total time ~2-4 min (not 10+)
-        import threading
+        # Use real OS threads (not eventlet green threads) so heavy I/O doesn't deadlock
+        try:
+            import eventlet.patcher as _ep_inner
+            threading = _ep_inner.original('threading')
+        except (ImportError, AttributeError):
+            import threading
         clip_result = [None]
         def load_clip_thread():
             try:
@@ -547,8 +552,16 @@ class EnsembleDetector:
 # ---------------------------------------------------------------------------
 # Global ensemble lifecycle: background preload, per-model status, resilient retry
 # ---------------------------------------------------------------------------
-import threading as _threading
 import time as _time
+
+# Use REAL OS threads, not eventlet green threads.
+# When eventlet monkey-patches threading, green threads can't do heavy CPU/IO
+# (model downloads, PyTorch loads) without blocking the hub and deadlocking.
+try:
+    import eventlet.patcher as _ep
+    _threading = _ep.original('threading')  # real OS threading module
+except (ImportError, AttributeError):
+    import threading as _threading
 
 _ensemble_instance: Optional[EnsembleDetector] = None
 _ensemble_loading_started = False

--- a/ai_model/ensemble_detector.py
+++ b/ai_model/ensemble_detector.py
@@ -695,11 +695,8 @@ def detect_fake_ensemble(video_path: str, num_frames: int = 16) -> Dict[str, Any
         }
 
 
-# ---------------------------------------------------------------------------
-# AUTO-START: Begin loading immediately when this module is imported.
-# This runs during app startup (api.py import), so by the time a user logs in
-# and navigates to Forensics the models are likely already loaded.
-# It is a daemon thread — zero impact on login, health checks, or any endpoint.
-# ---------------------------------------------------------------------------
-start_background_ensemble_load()
+# NOTE: Do NOT auto-start at module import. With gunicorn preload_app=True,
+# the import runs in the master process; threads die when workers are forked.
+# Instead, api.py triggers start_background_ensemble_load() on the first
+# HTTP request (any endpoint), when the worker and eventlet hub are alive.
 

--- a/ai_model/ensemble_detector.py
+++ b/ai_model/ensemble_detector.py
@@ -637,30 +637,62 @@ def init_ensemble_blocking() -> Optional[EnsembleDetector]:
 
 
 def start_background_ensemble_load() -> None:
-    """Start loading the ensemble in a background thread. Returns immediately.
-    Safe to call multiple times — subsequent calls are no-ops unless a retry is due."""
+    """Start loading the ensemble in the background. Returns immediately.
+    Safe to call multiple times — subsequent calls are no-ops unless a retry is due.
+
+    When running under eventlet (production with gunicorn+eventlet), uses
+    eventlet.tpool to run in a real OS thread so heavy PyTorch/model loading
+    does not deadlock the green thread hub. This is the same mechanism the
+    scan analysis path uses for detect_fake."""
     global _ensemble_loading_started, _ensemble_overall_status
     with _ensemble_loading_lock:
         if _ensemble_instance is not None:
             return
         if _ensemble_loading_started and _ensemble_overall_status == 'loading':
-            return  # already in progress
-        # Allow retry after cooldown on failure
+            # Detect stuck loads: if loading for >10 min, allow retry
+            if _ensemble_load_start_time and (_time.time() - _ensemble_load_start_time) > 600:
+                logger.warning("Ensemble load appears stuck (>10 min). Resetting for retry...")
+                _ensemble_loading_started = False
+                _ensemble_overall_status = 'idle'
+            else:
+                return  # already in progress
         if _ensemble_overall_status == 'failed':
             if _last_fail_time and (_time.time() - _last_fail_time) < _RETRY_COOLDOWN:
                 return  # too soon to retry
             logger.info(f"Retrying ensemble load (attempt {_ensemble_fail_count + 1}) after cooldown...")
-            _ensemble_overall_status = 'loading'
         _ensemble_loading_started = True
+        _ensemble_overall_status = 'loading'
 
-    def _run():
+    def _run_load():
         try:
             init_ensemble_blocking()
         except Exception:
             pass  # status already set inside init_ensemble_blocking
-    t = _threading.Thread(target=_run, daemon=True, name='ensemble-loader')
-    t.start()
-    logger.info("Ensemble load started in background thread.")
+
+    # Detect eventlet: if active, use tpool (real OS threads) to avoid deadlock.
+    # Green threads cannot do heavy CPU/IO (PyTorch model loading) without
+    # blocking the hub. tpool.execute runs in a real thread that eventlet manages.
+    _use_eventlet_tpool = False
+    try:
+        import eventlet
+        if hasattr(eventlet, 'sleep') and _threading.__name__ != 'threading':
+            _use_eventlet_tpool = True
+    except ImportError:
+        pass
+
+    if _use_eventlet_tpool:
+        import eventlet as _ev
+        def _tpool_wrapper():
+            try:
+                _ev.tpool.execute(init_ensemble_blocking)
+            except Exception as e:
+                logger.warning(f"Ensemble tpool load failed: {e}")
+        _ev.spawn_n(_tpool_wrapper)
+        logger.info("Ensemble load started via eventlet.tpool (real OS thread).")
+    else:
+        t = _threading.Thread(target=_run_load, daemon=True, name='ensemble-loader')
+        t.start()
+        logger.info("Ensemble load started in background thread.")
 
 
 def get_ensemble_detector(timeout: Optional[float] = None) -> Optional[EnsembleDetector]:

--- a/ai_model/ensemble_detector.py
+++ b/ai_model/ensemble_detector.py
@@ -673,16 +673,17 @@ def start_background_ensemble_load() -> None:
     _use_eventlet = os.getenv('SOCKETIO_ASYNC_MODE', '').lower() == 'eventlet'
 
     if _use_eventlet:
-        # Green threads deadlock on heavy PyTorch loads. Use eventlet.tpool
+        # Green threads deadlock on heavy PyTorch loads. Use eventlet tpool
         # (real OS thread pool) — same mechanism the scan analysis path uses.
         import eventlet as _ev
+        from eventlet import tpool as _tpool
         def _tpool_wrapper():
             try:
-                _ev.tpool.execute(init_ensemble_blocking)
+                _tpool.execute(init_ensemble_blocking)
             except Exception as e:
                 logger.warning(f"Ensemble tpool load failed: {e}")
         _ev.spawn_n(_tpool_wrapper)
-        logger.info("Ensemble load started via eventlet.tpool (real OS thread).")
+        logger.info("Ensemble load started via eventlet tpool (real OS thread).")
     else:
         t = _threading.Thread(target=_run_load, daemon=True, name='ensemble-loader')
         t.start()

--- a/ai_model/ensemble_detector.py
+++ b/ai_model/ensemble_detector.py
@@ -82,128 +82,94 @@ class EnsembleDetector:
             self.device = device if device else ('cuda' if torch.cuda.is_available() else 'cpu')
         logger.info(f"🔧 Initializing EnsembleDetector on device: {self.device}")
         
-        # Load CLIP + ResNet + V13 + Xception + EfficientNet ALL IN PARALLEL so total time ~2-4 min (not 10+)
-        # Use real OS threads (not eventlet green threads) so heavy I/O doesn't deadlock
-        try:
-            import eventlet.patcher as _ep_inner
-            threading = _ep_inner.original('threading')
-        except (ImportError, AttributeError):
-            import threading
-        clip_result = [None]
-        def load_clip_thread():
-            try:
-                from .enhanced_detector import _detector_instance as enhanced_singleton
-                if enhanced_singleton is not None:
-                    clip_result[0] = enhanced_singleton
-                    logger.info("✅ Reusing existing CLIP detector (singleton)")
-                    return
-                from .enhanced_detector import get_enhanced_detector
-                clip_result[0] = get_enhanced_detector(
-                    device=self.device,
-                    clip_model_name=clip_model_name,
-                    clip_pretrained=clip_pretrained
-                )
-                logger.info("✅ CLIP detector loaded")
-            except (ImportError, AttributeError, Exception) as e:
-                logger.warning(f"⚠️  CLIP: {e}")
-        
-        # Load ResNet, V13, Xception, EfficientNet in parallel with CLIP
+        # Load models SEQUENTIALLY — no child threads.
+        # This runs inside eventlet.tpool.execute() so it's already in a real
+        # OS thread. Child threads deadlock under eventlet; sequential is reliable.
+        import time as _t
         self.resnet_model = None
         self.v13_detector = None
         self.xception_detector = None
         self.efficientnet_detector = None
-        logger.info("📦 Loading CLIP, ResNet50, V13, XceptionNet, EfficientNet in parallel (max 4 min)...")
-        
-        def _load_state_dict_resnet(path: str):
-            """Load state dict from .pth or .safetensors (safetensors is much faster)."""
-            base, ext = os.path.splitext(path)
-            # Prefer safetensors if available (faster load, no pickle)
-            if ext.lower() == '.pth':
-                safetensors_path = base + '.safetensors'
-                if os.path.exists(safetensors_path):
-                    try:
-                        from safetensors.torch import load_file
-                        return load_file(safetensors_path, device=self.device)
-                    except Exception:
-                        pass
-            # .pth: use weights_only=True when supported (PyTorch 2.0+, faster/safer)
-            try:
-                ckpt = torch.load(path, map_location=self.device, weights_only=True)
-            except (TypeError, Exception):
-                ckpt = torch.load(path, map_location=self.device)
-            return ckpt.get('state_dict', ckpt) if isinstance(ckpt, dict) else ckpt
+        logger.info("📦 Loading ensemble models sequentially (CLIP → ResNet → V13 → EfficientNet)...")
 
-        def load_resnet():
-            try:
-                model = ResNetDeepfakeClassifier(model_name='resnet50', pretrained=False)
-                for path in [resnet_model_path, 'ai_model/resnet_resnet50_final.pth', 'ai_model/resnet_resnet50_best.pth',
-                             'resnet_resnet50_final.pth', 'resnet_resnet50_best.pth']:
-                    if path and os.path.exists(path):
-                        state = _load_state_dict_resnet(path)
-                        model.load_state_dict(state, strict=False)
-                        model.to(self.device)
-                        model.eval()
-                        logger.info(f"✅ ResNet50 loaded from: {path}")
-                        return model
-                logger.warning("⚠️  ResNet50 weights not found. Skipping ResNet.")
-            except Exception as e:
-                logger.warning(f"⚠️  ResNet50: {e}")
-            return None
-        
-        def load_v13_thread():
-            if not V13_AVAILABLE:
-                return None
-            try:
-                return get_deepfake_detector_v13(device=self.device)
-            except Exception as e:
-                logger.warning(f"⚠️  V13: {e}")
-                return None
-        
-        def load_xception_thread():
-            if not XCEPTION_AVAILABLE:
-                return None
-            try:
-                return get_xception_detector(device=self.device)
-            except Exception as e:
-                logger.warning(f"⚠️  XceptionNet: {e}")
-                return None
-        
-        def load_efficientnet_thread():
-            if not EFFICIENTNET_AVAILABLE:
-                return None
-            try:
-                return get_efficientnet_detector(device=self.device)
-            except Exception as e:
-                logger.warning(f"⚠️  EfficientNet: {e}")
-                return None
-        
-        resnet_result, v13_result, xception_result, eff_result = [None], [None], [None], [None]
-        t_clip = threading.Thread(target=load_clip_thread, daemon=True)
-        t_resnet = threading.Thread(target=lambda: resnet_result.__setitem__(0, load_resnet()), daemon=True)
-        t_v13 = threading.Thread(target=lambda: v13_result.__setitem__(0, load_v13_thread()), daemon=True)
-        t_xception = threading.Thread(target=lambda: xception_result.__setitem__(0, load_xception_thread()), daemon=True)
-        t_eff = threading.Thread(target=lambda: eff_result.__setitem__(0, load_efficientnet_thread()), daemon=True)
-        t_clip.start()
-        t_resnet.start()
-        t_v13.start()
-        t_xception.start()
-        t_eff.start()
-        for t in (t_clip, t_resnet, t_v13, t_xception, t_eff):
-            t.join(timeout=240.0)  # max 4 min for full parallel batch (CLIP + 4 others)
-        self.clip_detector = clip_result[0]
-        if self.clip_detector is None:
-            logger.warning("⚠️  CLIP did not load in time; creating in main thread...")
-            try:
+        # --- 1. CLIP (required) ---
+        _s = _t.time()
+        try:
+            from .enhanced_detector import _detector_instance as enhanced_singleton
+            if enhanced_singleton is not None:
+                self.clip_detector = enhanced_singleton
+                logger.info(f"✅ CLIP reused (singleton) [{_t.time()-_s:.1f}s]")
+            else:
                 from .enhanced_detector import get_enhanced_detector
-                self.clip_detector = get_enhanced_detector(device=self.device, clip_model_name=clip_model_name, clip_pretrained=clip_pretrained)
+                self.clip_detector = get_enhanced_detector(
+                    device=self.device,
+                    clip_model_name=clip_model_name,
+                    clip_pretrained=clip_pretrained
+                )
+                logger.info(f"✅ CLIP loaded [{_t.time()-_s:.1f}s]")
+        except Exception as e:
+            raise RuntimeError(f"CLIP required for detection: {e}") from e
+
+        # --- 2. ResNet50 (local weights, fast) ---
+        _s = _t.time()
+        try:
+            model = ResNetDeepfakeClassifier(model_name='resnet50', pretrained=False)
+            for path in [resnet_model_path, 'ai_model/resnet_resnet50_final.pth',
+                         'ai_model/resnet_resnet50_best.pth',
+                         'resnet_resnet50_final.pth', 'resnet_resnet50_best.pth']:
+                if path and os.path.exists(path):
+                    base, ext = os.path.splitext(path)
+                    st_path = base + '.safetensors'
+                    if ext.lower() == '.pth' and os.path.exists(st_path):
+                        try:
+                            from safetensors.torch import load_file
+                            state = load_file(st_path, device=self.device)
+                        except Exception:
+                            state = torch.load(path, map_location=self.device, weights_only=True)
+                    else:
+                        try:
+                            state = torch.load(path, map_location=self.device, weights_only=True)
+                        except (TypeError, Exception):
+                            state = torch.load(path, map_location=self.device)
+                    if isinstance(state, dict) and 'state_dict' in state:
+                        state = state['state_dict']
+                    model.load_state_dict(state, strict=False)
+                    model.to(self.device)
+                    model.eval()
+                    self.resnet_model = model
+                    logger.info(f"✅ ResNet50 loaded from {path} [{_t.time()-_s:.1f}s]")
+                    break
+            if self.resnet_model is None:
+                logger.warning(f"⚠️  ResNet50 weights not found [{_t.time()-_s:.1f}s]")
+        except Exception as e:
+            logger.warning(f"⚠️  ResNet50: {e} [{_t.time()-_s:.1f}s]")
+
+        # --- 3. V13 (HuggingFace download, can be slow) ---
+        _s = _t.time()
+        if V13_AVAILABLE:
+            try:
+                self.v13_detector = get_deepfake_detector_v13(device=self.device)
+                logger.info(f"✅ V13 loaded [{_t.time()-_s:.1f}s]")
             except Exception as e:
-                raise RuntimeError(f"CLIP required for detection: {e}") from e
-        self.resnet_model = resnet_result[0]
-        self.v13_detector = v13_result[0]
-        self.xception_detector = xception_result[0]
-        self.efficientnet_detector = eff_result[0]
-        if t_v13.is_alive():
-            logger.warning("⚠️  V13 loading timed out (4 min). Ensemble will use CLIP + ResNet + XceptionNet.")
+                logger.warning(f"⚠️  V13: {e} [{_t.time()-_s:.1f}s]")
+
+        # --- 4. EfficientNet (pretrained, fast) ---
+        _s = _t.time()
+        if EFFICIENTNET_AVAILABLE:
+            try:
+                self.efficientnet_detector = get_efficientnet_detector(device=self.device)
+                logger.info(f"✅ EfficientNet loaded [{_t.time()-_s:.1f}s]")
+            except Exception as e:
+                logger.warning(f"⚠️  EfficientNet: {e} [{_t.time()-_s:.1f}s]")
+
+        # --- 5. XceptionNet (optional) ---
+        _s = _t.time()
+        if XCEPTION_AVAILABLE:
+            try:
+                self.xception_detector = get_xception_detector(device=self.device)
+                logger.info(f"✅ XceptionNet loaded [{_t.time()-_s:.1f}s]")
+            except Exception as e:
+                logger.warning(f"⚠️  XceptionNet: {e} [{_t.time()-_s:.1f}s]")
         if self.v13_detector and getattr(self.v13_detector, 'model_loaded', False):
             logger.info("✅ DeepFake Detector V13 loaded successfully!")
         if self.xception_detector:

--- a/api.py
+++ b/api.py
@@ -458,6 +458,26 @@ def index():
     #     return redirect(url_for('login'))
     return render_template('index.html')
 
+# ---------------------------------------------------------------------------
+# Trigger ensemble preload on the FIRST request to ANY endpoint (health, login,
+# dashboard, etc.). By the time the user navigates to Forensics, models are
+# likely loaded. Runs once, never blocks — just kicks off the background thread.
+# ---------------------------------------------------------------------------
+_ensemble_preload_triggered = False
+
+@app.before_request
+def _trigger_ensemble_preload():
+    global _ensemble_preload_triggered
+    if not _ensemble_preload_triggered:
+        _ensemble_preload_triggered = True
+        try:
+            from ai_model.ensemble_detector import start_background_ensemble_load
+            start_background_ensemble_load()
+            logger.info("Ensemble background preload triggered by first request.")
+        except Exception as e:
+            logger.warning("Ensemble preload trigger failed: %s", e)
+
+
 @app.route('/api/health')
 def health_check():
     """Health check endpoint"""

--- a/api.py
+++ b/api.py
@@ -94,7 +94,7 @@ logging.basicConfig(level=logging.INFO)
 def _ensure_ensemble_loaded():
     """
     Ensure ensemble load is started (in background) and return True only if already loaded.
-    Never blocks the request thread. First scan gets 503 "retry in 3 min"; next scan proceeds.
+    Never blocks the request thread.
     """
     try:
         from ai_model.ensemble_detector import get_ensemble_detector, start_background_ensemble_load
@@ -466,6 +466,18 @@ def health_check():
         'timestamp': datetime.now().isoformat(),
         'version': '2.0.0'
     })
+
+
+@app.route('/api/ensemble-status')
+def ensemble_status():
+    """Return ensemble model loading status (lightweight, no auth required).
+    Frontend polls this to show progress and auto-retry scans."""
+    try:
+        from ai_model.ensemble_detector import get_ensemble_status
+        return jsonify(get_ensemble_status())
+    except Exception as e:
+        logger.warning("ensemble-status error: %s", e)
+        return jsonify({'status': 'unknown', 'ready': False, 'progress_pct': 0, 'models': {}})
 
 
 # =============================================================================
@@ -1135,10 +1147,16 @@ def analyze_video():
         finally:
             _stop_heartbeat.set()
         if not ensemble_ok:
+            try:
+                from ai_model.ensemble_detector import get_ensemble_status
+                status = get_ensemble_status()
+            except Exception:
+                status = {'status': 'loading', 'progress_pct': 0, 'ready': False}
             return jsonify({
-                'error': 'Models are loading (takes 2–4 min). Please click Scan again in 3 minutes.',
+                'error': 'Models are loading. The scan will start automatically when ready.',
                 'ensemble_unavailable': True,
-                'retry_after_seconds': 180
+                'retry_after_seconds': 10,
+                'ensemble_status': status,
             }), 503
         model_type_param = request.form.get('model_type') or 'enhanced'
         try:
@@ -1535,10 +1553,16 @@ def analyze_video_from_url():
         finally:
             _stop_heartbeat.set()
         if not ensemble_ok:
+            try:
+                from ai_model.ensemble_detector import get_ensemble_status
+                status = get_ensemble_status()
+            except Exception:
+                status = {'status': 'loading', 'progress_pct': 0, 'ready': False}
             return jsonify({
-                'error': 'Models are loading (takes 2–4 min). Please click Scan again in 3 minutes.',
+                'error': 'Models are loading. The scan will start automatically when ready.',
                 'ensemble_unavailable': True,
-                'retry_after_seconds': 180
+                'retry_after_seconds': 10,
+                'ensemble_status': status,
             }), 503
         try:
             if os.getenv('SOCKETIO_ASYNC_MODE', '').lower() == 'eventlet':

--- a/api.py
+++ b/api.py
@@ -1163,21 +1163,11 @@ def analyze_video():
         _heartbeat_thread = threading.Thread(target=_progress_heartbeat, daemon=True)
         _heartbeat_thread.start()
         try:
-            ensemble_ok = _ensure_ensemble_loaded()
+            _ensure_ensemble_loaded()
         finally:
             _stop_heartbeat.set()
-        if not ensemble_ok:
-            try:
-                from ai_model.ensemble_detector import get_ensemble_status
-                status = get_ensemble_status()
-            except Exception:
-                status = {'status': 'loading', 'progress_pct': 0, 'ready': False}
-            return jsonify({
-                'error': 'Models are loading. The scan will start automatically when ready.',
-                'ensemble_unavailable': True,
-                'retry_after_seconds': 10,
-                'ensemble_status': status,
-            }), 503
+        # No 503 — if ensemble isn't preloaded, it loads inline inside tpool.execute
+        # (first scan takes 2-4 min; subsequent scans are instant)
         model_type_param = request.form.get('model_type') or 'enhanced'
         try:
             if os.getenv('SOCKETIO_ASYNC_MODE', '').lower() == 'eventlet':
@@ -1569,21 +1559,10 @@ def analyze_video_from_url():
         _heartbeat_thread = threading.Thread(target=_progress_heartbeat, daemon=True)
         _heartbeat_thread.start()
         try:
-            ensemble_ok = _ensure_ensemble_loaded()
+            _ensure_ensemble_loaded()
         finally:
             _stop_heartbeat.set()
-        if not ensemble_ok:
-            try:
-                from ai_model.ensemble_detector import get_ensemble_status
-                status = get_ensemble_status()
-            except Exception:
-                status = {'status': 'loading', 'progress_pct': 0, 'ready': False}
-            return jsonify({
-                'error': 'Models are loading. The scan will start automatically when ready.',
-                'ensemble_unavailable': True,
-                'retry_after_seconds': 10,
-                'ensemble_status': status,
-            }), 503
+        # No 503 — ensemble loads inline inside tpool if needed
         try:
             if os.getenv('SOCKETIO_ASYNC_MODE', '').lower() == 'eventlet':
                 import eventlet  # type: ignore

--- a/secureai-guardian/components/Scanner.tsx
+++ b/secureai-guardian/components/Scanner.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { ScanResult } from '../types';
-import { analyzeVideo, analyzeVideoFromUrl, checkBackendHealth } from '../services/apiService';
+import { analyzeVideo, analyzeVideoFromUrl, checkBackendHealth, waitForEnsemble, EnsembleStatus } from '../services/apiService';
 import { ReconnectingWebSocket, isWebSocketSupported } from '../services/websocketService';
 
 interface ScannerProps {
@@ -247,12 +247,50 @@ const Scanner: React.FC<ScannerProps> = ({ onComplete }) => {
       // Otherwise, WebSocket will handle completion via onComplete callback
 
     } catch (err) {
+      // ---- Ensemble still loading: show progress and auto-retry ----
+      if (err instanceof Error && err.message === '__ENSEMBLE_LOADING__') {
+        setTerminalLogs(prev => [...prev.slice(-6),
+          '[SYS] Detection models are warming up in the background...',
+          '[SYS] Your scan will start automatically when ready.',
+        ]);
+        setScanStatus('LOADING_NEURAL_MODELS...');
+        setProgress(5);
+
+        try {
+          await waitForEnsemble((status: EnsembleStatus) => {
+            const pct = Math.max(5, Math.min(status.progress_pct, 90));
+            setProgress(pct);
+            const loaded = Object.entries(status.models)
+              .filter(([, s]) => s === 'loaded')
+              .map(([n]) => n.toUpperCase());
+            if (loaded.length > 0) {
+              setTerminalLogs(prev => [...prev.slice(-6),
+                `[NEURAL] ${loaded.join(', ')} online (${status.models_loaded}/${status.models_total}) — ${Math.round(status.elapsed_seconds)}s`,
+              ]);
+            }
+            setScanStatus(`LOADING_NEURAL_MODELS... ${pct}%`);
+          });
+          // Models ready — auto-retry the scan
+          setTerminalLogs(prev => [...prev.slice(-6), '[SYS] Models ready. Starting analysis...']);
+          setScanStatus('UPLOADING_MEDIA...');
+          setProgress(10);
+          // Re-run the analysis (recursive call, but ensemble is now loaded so it won't loop)
+          await startAnalysis();
+          return;
+        } catch (waitErr) {
+          const msg = waitErr instanceof Error ? waitErr.message : 'Model loading failed.';
+          setError(msg);
+          setIsScanning(false);
+          setTerminalLogs(prev => [...prev.slice(-6), `[ERROR] ${msg}`]);
+          return;
+        }
+      }
+
       if (wsConnection) {
         wsConnection.close();
       }
       const errorMessage = err instanceof Error ? err.message : 'Analysis failed. Please try again.';
       setError(errorMessage);
-      // Carry through structured error codes (e.g., X_AUTH_REQUIRED)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       setErrorCode((err as any)?.code || null);
       setIsScanning(false);

--- a/secureai-guardian/services/apiService.ts
+++ b/secureai-guardian/services/apiService.ts
@@ -280,7 +280,10 @@ export async function analyzeVideo(
           } else if (response.status === 413) {
             errorMessage = 'File too large. Maximum size is 500MB.';
           } else if (response.status === 503 && errorData.ensemble_unavailable) {
-            errorMessage = errorData.error || 'Models are loading (2–4 min). Please click Scan again in 3 minutes.';
+            // Models still loading — throw a special marker so we can auto-retry
+            const retryErr = new Error('__ENSEMBLE_LOADING__');
+            (retryErr as any).ensembleStatus = errorData.ensemble_status;
+            throw retryErr;
         } else if (response.status === 503) {
           errorMessage = errorData.error || 'Service temporarily unavailable. Please retry.';
         } else if (response.status === 500) {
@@ -288,6 +291,8 @@ export async function analyzeVideo(
         }
         }
       } catch (parseError) {
+        // Re-throw ensemble loading marker
+        if (parseError instanceof Error && parseError.message === '__ENSEMBLE_LOADING__') throw parseError;
         if (response.status === 504) {
           errorMessage = 'Request timed out. The server took too long to respond. Try a shorter video or try again.';
         } else if (response.status === 502 || response.status === 503) {
@@ -313,6 +318,8 @@ export async function analyzeVideo(
     }
   } catch (error) {
     clearTimeout(timeoutId);
+    // If ensemble is loading, re-throw marker so Scanner can handle it gracefully
+    if (error instanceof Error && error.message === '__ENSEMBLE_LOADING__') throw error;
     console.error('Video analysis error:', error);
     // Connection dropped or aborted after long run: backend may have finished
     const msg = error instanceof Error ? error.message : '';
@@ -367,7 +374,9 @@ export async function analyzeVideoFromUrl(
         }
         
         if (response.status === 503 && errorData.ensemble_unavailable) {
-          errorMessage = errorData.error || 'Models are loading (2–4 min). Please click Scan again in 3 minutes.';
+          const retryErr = new Error('__ENSEMBLE_LOADING__');
+          (retryErr as any).ensembleStatus = errorData.ensemble_status;
+          throw retryErr;
         } else if (response.status === 503) {
           errorMessage = errorData.error || 'Service temporarily unavailable. Please retry.';
         } else if (response.status === 400) {
@@ -386,6 +395,7 @@ export async function analyzeVideoFromUrl(
           errorMessage = 'Backend unavailable or overloaded. Please try again in a minute.';
         }
       } catch (parseError) {
+        if (parseError instanceof Error && parseError.message === '__ENSEMBLE_LOADING__') throw parseError;
         if (response.status === 504) {
           errorMessage = 'Request timed out. The server took too long to respond. Try a shorter video or try again.';
         } else if (response.status === 502 || response.status === 503) {
@@ -414,6 +424,7 @@ export async function analyzeVideoFromUrl(
     }
   } catch (error) {
     clearTimeout(timeoutId);
+    if (error instanceof Error && error.message === '__ENSEMBLE_LOADING__') throw error;
     console.error('Video URL analysis error:', error);
     const msg = error instanceof Error ? error.message : '';
     if (msg === 'Failed to fetch' || (msg.includes('fetch') && msg.toLowerCase().includes('failed'))) {
@@ -428,6 +439,63 @@ export async function analyzeVideoFromUrl(
     }
     throw error;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Ensemble status polling — lets the frontend show real loading progress
+// and auto-retry scans once models are ready (zero user friction).
+// ---------------------------------------------------------------------------
+export interface EnsembleStatus {
+  status: 'idle' | 'loading' | 'ready' | 'failed' | 'unknown';
+  progress_pct: number;
+  models: Record<string, string>;
+  models_loaded: number;
+  models_total: number;
+  elapsed_seconds: number;
+  ready: boolean;
+}
+
+export async function getEnsembleStatus(): Promise<EnsembleStatus> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/ensemble-status`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!response.ok) return { status: 'unknown', progress_pct: 0, models: {}, models_loaded: 0, models_total: 5, elapsed_seconds: 0, ready: false };
+    return await response.json();
+  } catch {
+    return { status: 'unknown', progress_pct: 0, models: {}, models_loaded: 0, models_total: 5, elapsed_seconds: 0, ready: false };
+  }
+}
+
+/**
+ * Wait for the ensemble to become ready, calling onProgress with status updates.
+ * Resolves when ready, rejects after maxWaitMs.
+ */
+export function waitForEnsemble(
+  onProgress?: (status: EnsembleStatus) => void,
+  maxWaitMs = 600000,  // 10 minutes max
+  pollMs = 3000,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + maxWaitMs;
+    const poll = async () => {
+      const status = await getEnsembleStatus();
+      onProgress?.(status);
+      if (status.ready) {
+        resolve();
+        return;
+      }
+      if (status.status === 'failed') {
+        // After failure, backend retries after cooldown — keep polling
+      }
+      if (Date.now() > deadline) {
+        reject(new Error('Model loading timed out. Please refresh and try again.'));
+        return;
+      }
+      setTimeout(poll, pollMs);
+    };
+    poll();
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
9 production bug fixes from master branch — all related to ensemble model loading and eventlet compatibility.

## Changes
- **Eventlet deadlock fix** — models now load sequentially inside `eventlet.tpool.execute()` instead of spawning child threads (child threads deadlock under eventlet)
- **Ensemble preload on first request** — `@app.before_request` hook triggers background load immediately on first hit to any endpoint; models are ready by the time user reaches Forensics
- **Removed 503 "retry in 3 min"** — scans no longer return 503 while models load; ensemble loads inline inside tpool if not preloaded yet
- **`/api/ensemble-status` endpoint** — frontend can poll loading progress and auto-retry scans
- **`SOCKETIO_ASYNC_MODE` env var detection** — replaces broken module name check for eventlet detection
- **tpool import fix** — `from eventlet import tpool` (was `eventlet.tpool`)
- Minor fixes: `global _identity_store`, `start_time` tracking, removed unnecessary noqa comments

## Context
These commits existed on master but not main. One conflict resolved: `secureai-guardian/package-lock.json` kept main's version (the conflict was in a docs-only commit that shouldn't have touched it).

## Test plan
- [ ] CI passes (unit tests, CodeQL, security scan)
- [ ] Verify ensemble loads in background on first request
- [ ] Verify `/api/ensemble-status` returns valid JSON
- [ ] Verify no 503 responses during model loading
- [ ] Test scan works end-to-end on droplet after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)