### PR TITLE
fix(ci): correct deploy.yml indentation (L42 syntax error)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,11 +36,10 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
     
     - name: Install system dependencies
-  run: |
-    sudo apt-get update
-    sudo apt-get install -y libgl1 libglib2.0-0
-
-- name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgl1 libglib2.0-0
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt || echo "Some requirements failed, continuing..."; fi


### PR DESCRIPTION
**Fixes 2nd CI failure after #21 merge.**

## Changes
- Fixed indentation for `Install system dependencies` and `Install dependencies` steps in `pre-deployment-checks`
- `run:` blocks now properly aligned under steps

## Root cause
Copy-paste indentation error exposed after #21 quote fix. L42 `run:` misaligned.

## Verify
Merge → push main → CI green on deploy.yml

Test:
```
git checkout main && git pull origin main
```